### PR TITLE
Try to make windows testing more reliable.

### DIFF
--- a/netcdf-by-coordinates.ipynb
+++ b/netcdf-by-coordinates.ipynb
@@ -56,7 +56,7 @@
      "output_type": "stream",
      "text": [
       "<class 'netCDF4._netCDF4.Dataset'>\n",
-      "root group (NETCDF4_CLASSIC data model, file format UNDEFINED):\n",
+      "root group (NETCDF4_CLASSIC data model, file format HDF5):\n",
       "    Conventions: CF-1.0\n",
       "    title: HYCOM ATLb2.00\n",
       "    institution: National Centers for Environmental Prediction\n",
@@ -443,20 +443,13 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 loops, best of 3: 2.4 s per loop\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%timeit ncfile = netCDF4.Dataset(filename,'r');latvar = ncfile.variables['Latitude'];lonvar = ncfile.variables['Longitude']\n",
-    "naive_slow(latvar, lonvar, 50.0, -140.0)"
+    "ncfile = netCDF4.Dataset(filename,'r')\n",
+    "latvar = ncfile.variables['Latitude']\n",
+    "lonvar = ncfile.variables['Longitude']"
    ]
   },
   {
@@ -470,13 +463,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "100 loops, best of 3: 3.1 ms per loop\n"
+      "1 loop, best of 3: 2.41 s per loop\n"
      ]
     }
    ],
    "source": [
-    "%%timeit ncfile = netCDF4.Dataset(filename,'r');latvar = ncfile.variables['Latitude'];lonvar = ncfile.variables['Longitude']\n",
-    "naive_fast(latvar, lonvar, 50.0, -140.0)"
+    "%%timeit\n",
+    "naive_slow(latvar, lonvar, 50.0, -140.0)"
    ]
   },
   {
@@ -490,13 +483,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 24.4 ms per loop\n"
+      "100 loops, best of 3: 4.78 ms per loop\n"
      ]
     }
    ],
    "source": [
-    "%%timeit ncfile = netCDF4.Dataset(filename,'r');latvar = ncfile.variables['Latitude'];lonvar = ncfile.variables['Longitude']\n",
-    "tunnel_fast(latvar, lonvar, 50.0, -140.0)"
+    "%%timeit\n",
+    "naive_fast(latvar, lonvar, 50.0, -140.0)"
    ]
   },
   {
@@ -510,18 +503,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loops, best of 3: 554 ms per loop\n"
+      "10 loops, best of 3: 26.3 ms per loop\n"
      ]
     }
    ],
    "source": [
-    "%%timeit ncfile = netCDF4.Dataset(filename,'r');latvar = ncfile.variables['Latitude'];lonvar = ncfile.variables['Longitude']\n",
-    "kdtree_fast(latvar, lonvar, 50.0, -140.0)"
+    "%%timeit\n",
+    "tunnel_fast(latvar, lonvar, 50.0, -140.0)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 loop, best of 3: 738 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "kdtree_fast(latvar, lonvar, 50.0, -140.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -545,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -594,7 +607,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -638,7 +651,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
@@ -695,7 +708,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -759,42 +772,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1000 loops, best of 3: 1.16 ms per loop\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%timeit ncfile = netCDF4.Dataset(filename, 'r')\n",
-    "ns = Naive_slow(ncfile,'Latitude','Longitude')"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 17,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1000 loops, best of 3: 1.21 ms per loop\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%timeit ncfile = netCDF4.Dataset(filename, 'r')\n",
-    "ns = Naive_fast(ncfile,'Latitude','Longitude')"
+    "ncfile = netCDF4.Dataset(filename, 'r')"
    ]
   },
   {
@@ -808,13 +792,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 19.8 ms per loop\n"
+      "1000 loops, best of 3: 1.15 ms per loop\n"
      ]
     }
    ],
    "source": [
-    "%%timeit ncfile = netCDF4.Dataset(filename, 'r')\n",
-    "ns = Tunnel_fast(ncfile,'Latitude','Longitude')"
+    "%%timeit\n",
+    "ns = Naive_slow(ncfile,'Latitude','Longitude')"
    ]
   },
   {
@@ -828,20 +812,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loops, best of 3: 547 ms per loop\n"
+      "1000 loops, best of 3: 1.12 ms per loop\n"
      ]
     }
    ],
    "source": [
-    "%%timeit ncfile = netCDF4.Dataset(filename, 'r')\n",
-    "ns = Kdtree_fast(ncfile,'Latitude','Longitude')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Query times for the four algorithms"
+    "%%timeit\n",
+    "ns = Naive_fast(ncfile,'Latitude','Longitude')"
    ]
   },
   {
@@ -855,13 +832,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loops, best of 3: 2.51 s per loop\n"
+      "10 loops, best of 3: 18.9 ms per loop\n"
      ]
     }
    ],
    "source": [
-    "%%timeit ncfile = netCDF4.Dataset(filename, 'r'); ns = Naive_slow(ncfile,'Latitude','Longitude')\n",
-    "iy,ix = ns.query(50.0, -140.0)"
+    "%%timeit\n",
+    "ns = Tunnel_fast(ncfile,'Latitude','Longitude')"
    ]
   },
   {
@@ -875,13 +852,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1000 loops, best of 3: 1.32 ms per loop\n"
+      "1 loop, best of 3: 751 ms per loop\n"
      ]
     }
    ],
    "source": [
-    "%%timeit ncfile = netCDF4.Dataset(filename, 'r'); ns = Naive_fast(ncfile,'Latitude','Longitude')\n",
-    "iy,ix = ns.query(50.0, -140.0)"
+    "%%timeit\n",
+    "ns = Kdtree_fast(ncfile,'Latitude','Longitude')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query times for the four algorithms"
    ]
   },
   {
@@ -895,12 +879,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "100 loops, best of 3: 2.78 ms per loop\n"
+      "1 loop, best of 3: 2.4 s per loop\n"
      ]
     }
    ],
    "source": [
-    "%%timeit ncfile = netCDF4.Dataset(filename, 'r'); ns = Tunnel_fast(ncfile,'Latitude','Longitude')\n",
+    "%%timeit ns = Naive_slow(ncfile,'Latitude','Longitude')\n",
     "iy,ix = ns.query(50.0, -140.0)"
    ]
   },
@@ -915,13 +899,65 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10000 loops, best of 3: 38.6 µs per loop\n"
+      "100 loops, best of 3: 2.42 ms per loop\n"
      ]
     }
    ],
    "source": [
-    "%%timeit ncfile = netCDF4.Dataset(filename, 'r'); ns = Kdtree_fast(ncfile,'Latitude','Longitude')\n",
+    "%%timeit ns = Naive_fast(ncfile,'Latitude','Longitude')\n",
     "iy,ix = ns.query(50.0, -140.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100 loops, best of 3: 2.43 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit ns = Tunnel_fast(ncfile,'Latitude','Longitude')\n",
+    "iy,ix = ns.query(50.0, -140.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The slowest run took 4.32 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+      "10000 loops, best of 3: 31.3 µs per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit ns = Kdtree_fast(ncfile,'Latitude','Longitude')\n",
+    "iy,ix = ns.query(50.0, -140.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "ncfile.close()"
    ]
   },
   {
@@ -933,7 +969,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "metadata": {
     "collapsed": false
    },
@@ -961,7 +997,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "metadata": {
     "collapsed": false
    },


### PR DESCRIPTION
For some reason, this notebook was triggering errors
"RuntimeError: NetCDF: Not a valid ID" on "ncfile.close()". It looks
like some kind of weird threading/race due to the timeits. I've moved
opening the dataset out of the benchmarking, which will hopefully
eliminate this problem.