### PR TITLE
MNT: Clean up environment (Fixes #85)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,9 +11,8 @@
    - netcdf4
    - owslib
    - metpy
-   - pint<0.7
+   - pint
    - siphon
    - xarray
    - anaconda-client
-   - icu
 


### PR DESCRIPTION
No longer need to depend on icu or pin pint version.