### PR TITLE
ENH: Add python-awips to configuration.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,4 +15,7 @@
    - siphon
    - xarray
    - anaconda-client
+   - pip
+   - pip:
+     - https://testpypi.python.org/packages/2d/42/7995409e0f71a7d61400809c74f05eb6cd6eaf18ce5e1940fddb2ebee58b/python-awips-0.9.5.tar.gz
 


### PR DESCRIPTION
This is currently relying upon a provisional package on the testing PyPI
site.