### PR TITLE
MNT: Fix broken links to GitHub resources.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@
    - matplotlib
    - cartopy
    - jupyter
+   - libnetcdf!=4.4.1.1
    - netcdf4
    - owslib
    - metpy

--- a/website/index.md
+++ b/website/index.md
@@ -34,12 +34,12 @@ to get a feel for what's in the workshop.
   - [python-awips](http://python-awips.readthedocs.io/)
 - Other Useful Resources
   - Git
-    - GitHub's [git cheatsheet](https://services.github.com/kit/downloads/github-git-cheat-sheet.pdf)
+    - GitHub's [git cheatsheet](https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf)
     - [Illustrated Git](http://illustrated-git.readthedocs.io)
     - Software Carpentry's [Git Novice Lesson](http://swcarpentry.github.io/git-novice/)
     - [Git it](https://github.com/jlord/git-it-electron), an interactive application showing how to use git
     - GitHub's [interactive git tutorial](https://try.github.io/)
-    - [Introduction to GitHub](https://github.github.com/on-demand/intro-to-github/)
+    - [Introduction to GitHub](https://services.github.com/on-demand/intro-to-github/)
   - [conda cheatsheet](http://conda.pydata.org/docs/_downloads/conda-cheatsheet.pdf) from ContinuumIO
   - MATLAB to Python [cross reference](http://mathesaurus.sourceforge.net/matlab-python-xref.pdf)
   - [Numpy](https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html) for MatLab users


### PR DESCRIPTION
Looks like GitHub moved some stuff on us.