### PR TITLE
Use XVFB for headless testing of scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,11 @@ install:
   - python --version
   - conda list
 
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+  
 script:
   - python run_notebooks.py
   - python notebooks/Command_Line_Tools/synopticplot.py  --gfslevel 850 --gfsfield Relative_humidity_isobaric --savefig --imgformat jpg

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,12 @@ install:
   - conda list
 
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
-  
+  - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
+      export DISPLAY=:99.0;
+      sh -e /etc/init.d/xvfb start;
+      sleep 10;
+    fi;
+
 script:
   - python run_notebooks.py
   - python notebooks/Command_Line_Tools/synopticplot.py  --gfslevel 850 --gfsfield Relative_humidity_isobaric --savefig --imgformat jpg


### PR DESCRIPTION
Headless testing of the scripts are failing on Travis again - use xvfb to get around this.