### PR TITLE
Skew-T Colorblindness Corrections

### DIFF
--- a/notebooks/Command_Line_Tools/skewt.py
+++ b/notebooks/Command_Line_Tools/skewt.py
@@ -5,23 +5,23 @@ from datetime import datetime
 
 import matplotlib.pyplot as plt
 import metpy.calc as mpcalc
-from metpy.io.upperair import get_upper_air_data
 from metpy.plots import Hodograph, SkewT
 from metpy.units import units
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from mpldatacursor import datacursor
 import numpy as np
+from siphon.simplewebservice.wyoming import WyomingUpperAir
 
 def get_sounding_data(date, station):
 
-    ds = get_upper_air_data(date, station)
+    df = WyomingUpperAir.request_data(date, station)
 
-    p = ds.variables['pressure'][:]
-    T = ds.variables['temperature'][:]
-    Td = ds.variables['dewpoint'][:]
-    u = ds.variables['u_wind'][:]
-    v = ds.variables['v_wind'][:]
-    windspeed = ds.variables['speed'][:]
+    p = df['pressure'].values * units(df.units['pressure'])
+    T = df['temperature'].values * units(df.units['temperature'])
+    Td = df['dewpoint'].values * units(df.units['dewpoint'])
+    u = df['u_wind'].values * units(df.units['u_wind'])
+    v = df['v_wind'].values * units(df.units['v_wind'])
+    windspeed = df['speed'].values * units(df.units['speed'])
 
     return p, T, Td, u, v, windspeed
 
@@ -38,7 +38,7 @@ def plot_sounding(date, station):
 
     # Plot the data
     skew.plot(p, T, color='tab:red')
-    skew.plot(p, Td, color='tab:green')
+    skew.plot(p, Td, color='blue')
 
     # Plot thermodynamic parameters and parcel path
     skew.plot(p, parcel_path, color='black')

--- a/notebooks/Model_Output/Downloading model fields with NCSS.ipynb
+++ b/notebooks/Model_Output/Downloading model fields with NCSS.ipynb
@@ -498,7 +498,7 @@
     "# Plot the data using normal plotting functions, in this case using\n",
     "# log scaling in Y, as dictated by the typical meteorological plot\n",
     "skew.plot(p, T, 'tab:red')\n",
-    "skew.plot(p, Td, 'tab:green')\n",
+    "skew.plot(p, Td, 'blue')\n",
     "skew.plot_barbs(p, u, v)\n",
     "skew.ax.set_ylim(1000, 100)\n",
     "skew.ax.set_xlim(-40, 60)\n",

--- a/notebooks/Skew_T/Upper Air and the Skew-T Log-P.ipynb
+++ b/notebooks/Skew_T/Upper Air and the Skew-T Log-P.ipynb
@@ -205,7 +205,7 @@
     "ax1 = plt.subplot()\n",
     "\n",
     "ax1.plot(T, p, color='tab:red')\n",
-    "ax1.plot(Td, p, color='tab:green')\n",
+    "ax1.plot(Td, p, color='blue')\n",
     "\n",
     "ax1.set_ylim(1000, 0)"
    ]
@@ -280,7 +280,7 @@
     "<div class=\"alert alert-success\">\n",
     "    <b>EXERCISE</b>:\n",
     "     <ul>\n",
-    "      <li>Add a green line for dewpoint.</li>\n",
+    "      <li>Add a blue line for dewpoint.</li>\n",
     "      <li>Set the x-axis limits to something sensible.</li>\n",
     "    </ul>\n",
     "</div>"
@@ -302,7 +302,7 @@
     "<button data-toggle=\"collapse\" data-target=\"#sol2\" class='btn btn-primary'>View Solution</button>\n",
     "<div id=\"sol2\" class=\"collapse\">\n",
     "```python\n",
-    "skew.plot(p, Td, color='tab:green')\n",
+    "skew.plot(p, Td, color='blue')\n",
     "skew.ax.set_xlim(-40, 60)\n",
     "\n",
     "fig\n",


### PR DESCRIPTION
It was pointed out that red/green skew-T plots are not easy for those with r/g colorblindness to read. We've also seen numerous other skew-T's with blue dew point profiles. This will close #271. 

I used straight `blue` as it doesn't get lost in the blue CIN shading like `tab:blue` does.