### PR TITLE
Tweaks to Exercises in Skew-T Notebook

### DIFF
--- a/notebooks/Skew_T/Upper Air and the Skew-T Log-P.ipynb
+++ b/notebooks/Skew_T/Upper Air and the Skew-T Log-P.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from metpy.units import pandas_dataframe_to_unit_arrays\n",
+    "from metpy.units import pandas_dataframe_to_unit_arrays, units\n",
     "\n",
     "data = pandas_dataframe_to_unit_arrays(df)"
    ]
@@ -293,7 +293,7 @@
     "<button data-toggle=\"collapse\" data-target=\"#sol2\" class='btn btn-primary'>View Solution</button>\n",
     "<div id=\"sol2\" class=\"collapse\">\n",
     "<code><pre>\n",
-    "skew.plot(data['pressure'], pressure['dewpoint'], color='blue')\n",
+    "skew.plot(data['pressure'], data['dewpoint'], color='blue')\n",
     "skew.ax.set_xlim(-40, 60)\n",
     "\n",
     "fig\n",


### PR DESCRIPTION
While going through this notebook, I found a small error in an exercise
solution, and that `units` was not imported (which is needed for the
bulk shear excercise). This should take care of both of those.