### PR TITLE
Add county example from MetPy docs to cartopy notebook.

### DIFF
--- a/notebooks/CartoPy/CartoPy.ipynb
+++ b/notebooks/CartoPy/CartoPy.ipynb
@@ -259,7 +259,37 @@
     }
    },
    "source": [
-    "You can also grab other features from the Natural Earth project: http://www.naturalearthdata.com/"
+    "You can also grab other features from the Natural Earth project: http://www.naturalearthdata.com/\n",
+    "\n",
+    "## US Counties\n",
+    "MetPy has US Counties built in at the 20m, 5m, and 500k resolutions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from metpy.plots import USCOUNTIES"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proj = ccrs.LambertConformal(central_longitude=-85.0, central_latitude=45.0)\n",
+    "\n",
+    "fig = plt.figure(figsize=(12, 9))\n",
+    "ax1 = fig.add_subplot(1, 3, 1, projection=proj)\n",
+    "ax2 = fig.add_subplot(1, 3, 2, projection=proj)\n",
+    "ax3 = fig.add_subplot(1, 3, 3, projection=proj)\n",
+    "\n",
+    "for scale, axis in zip(['20m', '5m', '500k'], [ax1, ax2, ax3]):\n",
+    "    axis.set_extent([270.25, 270.9, 38.15, 38.75], ccrs.Geodetic())\n",
+    "    axis.add_feature(USCOUNTIES.with_scale(scale), edgecolor='black')"
    ]
   },
   {


### PR DESCRIPTION
Closes #322 using the example of scales from the docs. We can also add counties to other notebooks as we have time.